### PR TITLE
AggregateRenderer.build_result to return nothing if there are no arguments

### DIFF
--- a/drf_aggregates/renderers.py
+++ b/drf_aggregates/renderers.py
@@ -133,8 +133,10 @@ class AggregateRenderer(renderers.BaseRenderer):
             if aggs:
                 qs = qs.annotate(**aggs) if query_args.get(_GROUPBY_KEYWORD) else qs.aggregate(**aggs)
 
-        result = list(qs.values(*keys)) if not isinstance(qs, dict) else qs
-        return result
+        if keys:
+            return list(qs.values(*keys)) if not isinstance(qs, dict) else qs
+        else:  # if there are no recognised arguments return nothing
+            return []
 
     def process_group_by(self, qs, field):
         '''

--- a/example/tests/test_renderers.py
+++ b/example/tests/test_renderers.py
@@ -12,7 +12,7 @@ class AggregatesAPITestCase(BaseTestCase):
 
     def test_default(self):
         results = self.query_agg_api(self.car_api_url)
-        self.assertEqual(len(results), len(self.cars))
+        self.assertEqual(len(results), 0)  # return nothing if there are no arguments
 
     def test_group_by(self):
         results = self.query_agg_api(
@@ -78,5 +78,3 @@ class AggregatesAPITestCase(BaseTestCase):
                 if car.manufacturer.country == row['country']
             ])
             self.assertEqual(count_cars, row['count_id'])
-
-


### PR DESCRIPTION
AggregateRenderer.build_result returns qs.values(*keys) but if keys is an empty list, qs.values(*keys) contains all attribute values, so instead of returning nothing it returns everything.