### PR TITLE
Fixes deprecated import for django-3.1

### DIFF
--- a/drf_aggregates/__init__.py
+++ b/drf_aggregates/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 12)
+VERSION = (0, 0, 13)
 
 __version__ = '.'.join(str(x) for x in VERSION[:(2 if VERSION[2] == 0 else 3)])  # noqa

--- a/drf_aggregates/renderers.py
+++ b/drf_aggregates/renderers.py
@@ -1,9 +1,11 @@
 import json
 from itertools import chain
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Case, CharField, Value, When
 from django.db.models.aggregates import Aggregate, Avg, Count, Max, Min, StdDev, Sum, Variance
-from django.db.models.fields import DateField, FieldDoesNotExist
+from django.db.models.fields import DateField
+
 from django.db.models.functions import Extract, TruncDate
 from rest_framework import renderers
 from rest_framework.utils import encoders


### PR DESCRIPTION
FieldDoesNotExist compat export was removed. 